### PR TITLE
Renaming plugin from 'Mautic Joomla Plugin' to just 'Mautic' since words...

### DIFF
--- a/language/en-GB/en-GB.plg_system_mautic.ini
+++ b/language/en-GB/en-GB.plg_system_mautic.ini
@@ -1,4 +1,4 @@
-PLG_MAUTIC_NAME="Mautic Joomla Plugin"
+PLG_MAUTIC_NAME="Mautic"
 PLG_MAUTIC_DESC="Plugin to integrate Mautic with Joomla. To insert a form to the Joomla article, use this syntax: {mauticform ID} where ID is identificator of Mautic form.<br /><br /> Example: <code>{mauticform 1}</code>"
 PLG_MAUTIC_BASE_URL="Base URL"
 PLG_MAUTIC_BASE_URL_DESC="The base URL for your Mautic installation (e.g. http://yourmauticsite.com)"

--- a/language/en-GB/en-GB.plg_system_mautic.sys.ini
+++ b/language/en-GB/en-GB.plg_system_mautic.sys.ini
@@ -1,2 +1,2 @@
-PLG_MAUTIC_NAME="Mautic Joomla Plugin"
+PLG_MAUTIC_NAME="Mautic"
 PLG_MAUTIC_DESC="Plugin to integrate Mautic with Joomla. <a href='index.php?option=com_plugins&filter_search=mautic'>Configure and enable</a> the plugin."


### PR DESCRIPTION
... 'Joomla' and 'plugin' cannot be in the extension name published at JED (https://docs.joomla.org/Extensions_name#Joomla_as_a_word)