### PR TITLE
Language cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 Mautic-Joomla plugin
 ====================
 
-This [Joomla](http://joomla.org) Plugin lets you insert the [Mautic](http://mautic.org) tracking gif image to your Joomla website and embed the Mautic forms to the Joomla articles.
+This [Joomla](http://joomla.org) Plugin lets you add the [Mautic](http://mautic.org) tracking gif to your Joomla website and embed Mautic forms in Joomla content.
 
 ### Form embed
 
-To embed a Mautic form into a Joomla article, insert this code snippet to the article content:
+To embed a Mautic form into Joomla content, insert this code snippet:
 
 	{mauticform ID}
 
-ID is identifikator of the Mautic form you want to embed. You can see the ID of the form in the URL of the form detail. For example for www.yourmautic.com/forms/view/1, ID = 1.
+ID is the identifier of the Mautic form you want to embed. You can see the ID of the form in the URL of the form detail. For example for www.yourmautic.com/forms/view/1, ID = 1.
 
 ## Developer notes
 
 ### Release of the new version
 
-This plugin uses Joomla Update Server which notifies Joomla admin about availability of new version of this plugin right in the Joomla administration. To do that, update version tag in mautic.xml in the master branch and then update version tag at updateserver.xml in the gh-pages brach accordingly.
+This plugin uses Joomla Update Server which notifies the Joomla admin about availability of new versions of this plugin. To do that, update the version tag in mautic.xml in the master branch and then update version tag at updateserver.xml in the gh-pages branch accordingly.
 
 [Current updateserver.xml](http://mautic.github.io/mautic-joomla/updateserver.xml)

--- a/language/en-GB/en-GB.plg_system_mautic.ini
+++ b/language/en-GB/en-GB.plg_system_mautic.ini
@@ -1,4 +1,4 @@
 PLG_MAUTIC_NAME="Mautic"
-PLG_MAUTIC_DESC="Plugin to integrate Mautic with Joomla. To insert a form to the Joomla article, use this syntax: {mauticform ID} where ID is identificator of Mautic form.<br /><br /> Example: <code>{mauticform 1}</code>"
+PLG_MAUTIC_DESC="Plugin to integrate Mautic with Joomla. To insert a form to Joomla content, use this syntax: {mauticform ID} where ID is identifier of the Mautic form.<br /><br /> Example: <code>{mauticform 1}</code>"
 PLG_MAUTIC_BASE_URL="Base URL"
 PLG_MAUTIC_BASE_URL_DESC="The base URL for your Mautic installation (e.g. http://yourmauticsite.com)"


### PR DESCRIPTION
Replace "Joomla article" with content.  Anywhere processing the onContentPrepare event should be able to use this plugin (i.e. custom HTML modules).

Some English language tweaks included.