### PR TITLE
URL sanitation regex fix

### DIFF
--- a/mautic.php
+++ b/mautic.php
@@ -71,7 +71,7 @@ class plgSystemMautic extends JPlugin
 		$encodedAttrs = urlencode(base64_encode(serialize($attrs)));
 
 		$buffer		= $document->getBuffer('component');
-		$image		= '<img style="display:none" src="' . trim($this->params->get('base_url'), ' \t\n\r\0\x0B/') . '/mtracking.gif?d=' . $encodedAttrs . '" />';
+		$image		= '<img style="display:none" src="' . trim($this->params->get('base_url'), " \t\n\r\0\x0B/") . '/mtracking.gif?d=' . $encodedAttrs . '" />';
 		$buffer		.= $image;
 
 		$document->setBuffer($buffer, 'component');
@@ -122,7 +122,7 @@ class plgSystemMautic extends JPlugin
 				if (isset($match[1]))
 				{
 					$formId = (int) $match[1];
-					$formTag = '<script type="text/javascript" src="' . trim($this->params->get('base_url'), ' \t\n\r\0\x0B/') . '/form/generate.js?id=' . $formId . '"></script>';
+					$formTag = '<script type="text/javascript" src="' . trim($this->params->get('base_url'), " \t\n\r\0\x0B/") . '/form/generate.js?id=' . $formId . '"></script>';
 					$article->text = str_replace($match[0], $formTag, $article->text);
 				}
 			}

--- a/mauticApiHelper.php
+++ b/mauticApiHelper.php
@@ -59,7 +59,7 @@ class mauticApiHelper
 	 */
 	public function getMauticBaseUrl()
 	{
-		return trim($this->params->get('base_url'), ' \t\n\r\0\x0B/');
+		return trim($this->params->get('base_url'), " \t\n\r\0\x0B/");
 	}
 
 	/**


### PR DESCRIPTION
The URL sanitation regex strips `n`, `r` and `t` letters and has to be in the double quotes.
